### PR TITLE
adds simplesamlphp/composer-xmlprovider-installer to list of allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
       "phpstan/extension-installer": true,
       "php-http/discovery": true,
       "simplesamlphp/composer-module-installer": true,
-      "simplesamlphp/composer-xmlprovider-installer": true
+      "simplesamlphp/composer-xmlprovider-installer": false
     },
     "bin-dir": "bin/",
     "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
       "drupal/core-vendor-hardening": true,
       "phpstan/extension-installer": true,
       "php-http/discovery": true,
-      "simplesamlphp/composer-module-installer": true
+      "simplesamlphp/composer-module-installer": true,
+      "simplesamlphp/composer-xmlprovider-installer": true
     },
     "bin-dir": "bin/",
     "sort-packages": true,


### PR DESCRIPTION
## Description

[v3.20.0 of GovCMS](https://github.com/govCMS/govCMS/releases) now includes SimpleSAML 2.3.2.

Something in that dependency tree includes the composer plugin [simplesamlphp/composer-xmlprovider-installer](https://github.com/simplesamlphp/composer-xmlprovider-installer). The upstream GovCMS project has [explicitly disabled the plugin](https://github.com/govCMS/GovCMS/compare/3.19.0...3.20.0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R136). This pr updates our composer.json to match. 




